### PR TITLE
Added Yoruba language support

### DIFF
--- a/Endpoints.md
+++ b/Endpoints.md
@@ -17,7 +17,8 @@
 | Spanish | `spanish` | Swahili | `swahili` |
 | Tamil | `tamil` | Turkish | `turkish` |
 | Ukrainian | `ukrainian` | Urdu | `urdu` |
-| Uzbek | `uzbek` | Vietnamese | `vietnamese` |
+| Uzbek | `uzbek` | Vietnamese | `vietnamese` 
+| Yoruba | `yoruba` |
 
 ## Types
 | Name | Endpoint | Description |

--- a/README.md
+++ b/README.md
@@ -3,23 +3,24 @@
 </p>
 
 # BBC News API
-Discover the world of news through the lens of the BBC News API. With access to a rich array of news content spanning over 30 languages, this API serves as a gateway to the latest updates from the British Broadcasting Corporation (BBC). Seamlessly integrate trusted news sources into your applications, offering users a diverse and comprehensive view of current events. Empower your audience with timely and reliable information, curated by one of the most respected news organizations worldwide.
+Discover the world of news through the lens of the BBC News API. With access to a rich array of news content spanning over 31 languages, this API serves as a gateway to the latest updates from the British Broadcasting Corporation (BBC). Seamlessly integrate trusted news sources into your applications, offering users a diverse and comprehensive view of current events. Empower your audience with timely and reliable information, curated by one of the most respected news organizations worldwide.
 
 <a href="https://bbc-api.vercel.app"><img src="https://img.shields.io/website?url=https%3A%2F%2Fbbc-api.vercel.app%2Fping&up_message=Online&down_message=Offline&label=API" height=22></a>
 <a href="https://bbc-api.vercel.app"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fbbc-api.vercel.app%2Fnews%3Flang%3Dbengali&query=%24%5B'elapsed%20time'%5D&label=Latency" height=22></a>
 <a href="https://bbc-api.vercel.app"><img src="https://img.shields.io/github/license/Sayad-Uddin-Tahsin/BBC-News-API" height=22></a>
+<a href="https://bbc-api.vercel.app"><img src="https://img.shields.io/badge/Supported%20Language-31-deepgreen" height=22></a>
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://web-badge-psi.vercel.app/visit-badge?theme=dark"><img alt="Requests Badge" src="https://web-badge-psi.vercel.app/visit-badge?theme=light"></picture>
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://web-badge-psi.vercel.app/latency-badge?theme=dark"><img alt="Latency Badge" src="https://web-badge-psi.vercel.app/latency-badge?theme=light"></picture>
 
 ## BBC
-BBC, British Broadcasting Corporation is a Trustable News Site. It has coverage of 30 languages. 
+BBC, British Broadcasting Corporation is a Trustable News Site. It has coverage of 31 languages. 
 
 ## API
-Application Programming Interface(API) is a way for two or more computer programs to communicate with each other. It is a type of software interface, offering a service to other pieces of software. A document or standard that describes how to build or use such a connection or interface is called an API specification.
+Application Programming Interface (API) is a way for two or more computer programs to communicate with each other. It is a type of software interface, offering a service to other pieces of software. A document or standard that describes how to build or use such a connection or interface is called an API specification.
 
 ## What is this API?
-BBC News API is the API for serving the news from all the BBC Services according to your need. This API has a coverage of 30 Languages (All supported languages by BBC)!
+BBC News API is the API for serving the news from all the BBC Services according to your need. This API has a coverage of 31 Languages!
 
 ### How it works?
 ```mermaid

--- a/api/main.py
+++ b/api/main.py
@@ -127,7 +127,8 @@ urls = {
     "sinhala": "https://bbc.com/sinhala",
     "tamil": "https://bbc.com/tamil",
     "uzbek": "https://bbc.com/uzbek",
-    "english": "https://bbc.com"
+    "english": "https://bbc.com",
+    "yoruba": "https://www.bbc.com/yoruba"
 }
 
 # ================ HELPING FUNCTIONS ================
@@ -348,7 +349,7 @@ async def ping():
 async def doc():
     lang = random.choice(list(urls.keys()))
     logger.info(f"{ctime()}: DOC endpoint called - 200")
-    return (flask.request.headers, flask.render_template("documentation.html", type="{type}", language="{language}", lang=lang.title(), urlForNews=f"https://{(flask.request.url).split('/')[2]}/news?lang={lang}", urlForLatest=f"https://{(flask.request.url).split('/')[2]}/latest?lang={lang}", currentYear=str(datetime.now(pytz.timezone("Asia/Dhaka")).year)))
+    return (flask.request.headers, flask.render_template("documentation.html", listOfLangs="\n".join([f"<li>{key.capitalize()}: <code>{key}</code></li>" for key in sorted(urls.keys())]), type="{type}", language="{language}", lang=lang.title(), urlForNews=f"https://{(flask.request.url).split('/')[2]}/news?lang={lang}", urlForLatest=f"https://{(flask.request.url).split('/')[2]}/latest?lang={lang}", currentYear=str(datetime.now(pytz.timezone("Asia/Dhaka")).year)))
 
 @app.route('/favicon.ico')
 def favicon():

--- a/api/templates/documentation.html
+++ b/api/templates/documentation.html
@@ -112,36 +112,7 @@
         <section>
             <h2><a id="languages" href="#languages" style="color: inherit; text-decoration: none;">Supported Languages</a></h2>
             <ul>
-                <li>Azeri: <code>azeri</code></li>
-                <li>Arabic: <code>arabic</code></li>
-                <li>Bengali: <code>bengali</code></li>
-                <li>Burmese: <code>burmese</code></li>
-                <li>Chinese: <code>chinese</code></li>
-                <li>English: <code>english</code></li>
-                <li>French: <code>french</code></li>
-                <li>Hausa: <code>hausa</code></li>
-                <li>Hindi: <code>hindi</code></li>
-                <li>Indonesian: <code>indonesian</code></li>
-                <li>Japanese: <code>japanese</code></li>
-                <li>Kinyarwanda: <code>kinyarwanda</code></li>
-                <li>Kirundi: <code>kirundi</code></li>
-                <li>Kyrgyz: <code>kyrgyz</code></li>
-                <li>Marathi: <code>marathi</code></li>
-                <li>Nepali: <code>nepali</code></li>
-                <li>Pashto: <code>pashto</code></li>
-                <li>Persian: <code>persian</code></li>
-                <li>Portuguese: <code>portuguese</code></li>
-                <li>Russian: <code>russian</code></li>
-                <li>Sinhala: <code>sinhala</code></li>
-                <li>Somali: <code>somali</code></li>
-                <li>Spanish: <code>spanish</code></li>
-                <li>Swahili: <code>swahili</code></li>
-                <li>Tamil: <code>tamil</code></li>
-                <li>Turkish: <code>turkish</code></li>
-                <li>Ukrainian: <code>ukrainian</code></li>
-                <li>Urdu: <code>urdu</code></li>
-                <li>Uzbek: <code>uzbek</code></li>
-                <li>Vietnamese: <code>vietnamese</code></li>
+                {{ listOfLangs|safe }}
             </ul>
         </section>
 

--- a/tmp/api.log
+++ b/tmp/api.log
@@ -1,1 +1,0 @@
-2024-08-05 18:35:46,842 - ENDPOINT [ENDPOINT] - INFO - 2024-08-06 00:35:46 : [ENDPOINT] NEWS (language: chinese, type: news) endpoint called - 200


### PR DESCRIPTION
BBC API will now use `https://www.bbc.com/yoruba` as news source for Yoruba Language